### PR TITLE
Allow #run proc to use the IO object given to the command

### DIFF
--- a/spec/clim_spec.cr
+++ b/spec/clim_spec.cr
@@ -1,7 +1,21 @@
 require "./spec_helper"
 
+class IoCommand < Clim
+  main do
+    desc "main command."
+    usage "main [sub_command] [arguments]"
+    run do |opts, args, io|
+      io.puts "Test"
+    end
+  end
+end
+
 describe Clim do
-  it "works" do
-    false.should eq(false)
+  describe "#start_parse" do
+    context "with custom IO - memory" do
+      io = IO::Memory.new
+      IoCommand.start_parse([] of String, io: io)
+      io.to_s.should eq "Test\n"
+    end
   end
 end

--- a/src/clim/command/macros.cr
+++ b/src/clim/command/macros.cr
@@ -91,14 +91,14 @@ class Clim
 
       macro run(&block)
         def run(io : IO)
-          return RunProc.new { io.puts help_template }.call(@parser.options, @parser.arguments) if @parser.options.help == true
-
           options = @parser.options
+          return RunProc.new { io.puts help_template }.call(options, @parser.arguments, io) if options.help == true
+          
           if options.responds_to?(:version)
-            return RunProc.new { io.puts version_str }.call(options, @parser.arguments) if options.version == true
+            return RunProc.new { io.puts version_str }.call(options, @parser.arguments, io) if options.version == true
           end
 
-          RunProc.new {{ block.id }} .call(@parser.options, @parser.arguments)
+          RunProc.new {{ block.id }} .call(options, @parser.arguments, io)
         end
       end
 
@@ -152,7 +152,7 @@ class Clim
           end
 
           alias OptionsForEachCommand = Options_{{ name.id.capitalize }}
-          alias RunProc = Proc(OptionsForEachCommand, Array(String), Nil)
+          alias RunProc = Proc(OptionsForEachCommand, Array(String), IO, Nil)
 
           property parser : Parser(OptionsForEachCommand)
           property name : String = {{name.id.stringify}}


### PR DESCRIPTION
Hey! Thanks for the lib! I've been using it for all my crystal command line utilities. There is one area that I think might be improved though.

This PR allows the run proc to get the IO object of the command. That in turn allows us to have a simpler implementation of testing output. After this is merged, it will be possible to stub `STDOUT` using `IO::Memory.new` like in the added spec.

