### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ targets:
   clim:
     main: src/clim.cr
 
-crystal: 1.0.0
+crystal: ">= 0.36.1, < 2.0.0"
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ targets:
   clim:
     main: src/clim.cr
 
-crystal: 0.36.1
+crystal: 1.0.0
 
 license: MIT


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on shards install.

there also should be a new version release as well.